### PR TITLE
Forbid, rather than deny, unstable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![crate_type = "lib"]
 
 #![allow(unused_must_use)]
-#![deny(unstable_features)]
+#![forbid(unstable_features)]
 
 /*!
 A simple gnuplot controller.


### PR DESCRIPTION
This allows compiling the library on the beta/stable channels, by forbidding (rather than denying) unstable features.  On these channels, `unstable_features` is forbidden, so compiling currently fails with the error:

```
src/lib.rs:9:9: 9:26 error: deny(unstable_features) overruled by outer forbid(unstable_features)
src/lib.rs:9 #![deny(unstable_features)]
                     ^~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `gnuplot`.
```

`forbid` is stronger than `deny`, so this continues to have the same impact of preventing unstable features from sneaking in.