### PR TITLE
Feature intoiterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly
+rust: stable
 notifications:
   email:
     on_success: never
@@ -8,19 +8,13 @@ env:
     - secure: cMdl5JREmUN4TRXLV2lZBfOWcNem52fZR60Jl0w39xYv0RbC+NM6EwSzYgyrJeYgMlONGpam+70nO8g/gmcqLw40ve22wvs4FqcANytquHUDultx2kpkfjqxzzTCYznqR082AK7Iva88RfULXJgEQRymVtF7LRod2t2PS7ma8To=
     - secure: NlRCSw0MsRyQQIx4KWCg2smQ1gwtA2EULEbTbHB4RlTCcLk6WWHJaF4pmQzZR0c7lNntOLbcqCrgrZ+ivstz6gIOtETNW2GaKJ5cepFkLxLVkAI60vIl9k3p4mv/y+bvtabsQrCoEZ2NCWqrtoZJP15JUdhiIHyZz2ejgE98YeU=
 script:
+  - cargo build
   - cargo test
-  - mkdir build
-  - cd build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=/tmp
-  - make -j
-  - make doc -j
-  - make install
-  - cd examples
-  - ./example1 --no-show
-  - ./example2 --no-show
-  - ./example3 --no-show
-  - ./example4 --no-show
-  - cd ..
+  - cargo doc
+  - cargo run --example example1 -- --no-show
+  - cargo run --example example2 -- --no-show
+  - cargo run --example example3 -- --no-show
+  - cargo run --example example4 -- --no-show
 after_success:
   - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
   - ../doc/gh_pages_upload.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ description = "Rust gnuplot controller"
 name = "gnuplot"
 path = "src/lib.rs"
 
+[dev-dependencies]
+getopts = "0.2"
+
 [[example]]
 
 name = "example1"

--- a/doc/gh_pages_upload.sh
+++ b/doc/gh_pages_upload.sh
@@ -1,8 +1,6 @@
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 	echo Starting gh-pages upload...
 
-	cp -r doc $HOME/doc
-
 	# Go to home and setup git
 	cd $HOME
 	git config --global user.email "travis@travis-ci.org"
@@ -14,7 +12,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 	# Copy over the documentation
 	cd gh-pages
 	rm -rf doc
-	cp -r $HOME/doc .
+	cp -r $HOME/target/doc .
 
 	# Add, commit and push files
 	git add -f --all .

--- a/examples/animation_example.rs
+++ b/examples/animation_example.rs
@@ -1,6 +1,4 @@
 // This file is released into Public Domain.
-#![feature(unboxed_closures)]
-
 extern crate gnuplot;
 
 use std::thread::sleep_ms;

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -47,23 +47,22 @@ impl Common
 {
 	pub fn new() -> Option<Common>
 	{
-		let args = env::args();
+		let args: Vec<_> = env::args().collect();
 
-		let opts =
-		&[
-			optflag("n", "no-show", "do not run the gnuplot process."),
-			optflag("h", "help", "show this help and exit."),
-			optopt("t", "terminal", "specify what terminal to use for gnuplot.", "TERM")
-		];
+        let mut opts = Options::new();
 
-		let matches = match getopts(args.collect::<Vec<_>>().tail(), opts)
+        opts.optflag("n", "no-show", "do not run the gnuplot process.");
+        opts.optflag("h", "help", "show this help and exit.");
+        opts.optopt("t", "terminal", "specify what terminal to use for gnuplot.", "TERM");
+
+		let matches = match opts.parse(&args[1..])
 		{
 			Ok(m) => m,
 			Err(f) => panic!("{}", f)
 		};
 		if matches.opt_present("h")
 		{
-			println!("{}", usage("A RustGnuplot example.", opts));
+			println!("{}", opts.usage("A RustGnuplot example."));
 			return None;
 		}
 

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -49,11 +49,11 @@ impl Common
 	{
 		let args: Vec<_> = env::args().collect();
 
-        let mut opts = Options::new();
+		let mut opts = Options::new();
 
-        opts.optflag("n", "no-show", "do not run the gnuplot process.");
-        opts.optflag("h", "help", "show this help and exit.");
-        opts.optopt("t", "terminal", "specify what terminal to use for gnuplot.", "TERM");
+		opts.optflag("n", "no-show", "do not run the gnuplot process.");
+		opts.optflag("h", "help", "show this help and exit.");
+		opts.optopt("t", "terminal", "specify what terminal to use for gnuplot.", "TERM");
 
 		let matches = match opts.parse(&args[1..])
 		{

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -1,8 +1,4 @@
 // This file is released into Public Domain.
-#![feature(unboxed_closures)]
-#![feature(collections)]
-#![feature(rustc_private)]
-
 extern crate gnuplot;
 
 use std::iter::repeat;
@@ -24,7 +20,7 @@ fn example(c: Common)
 	let y3 = y3.iter2();
 	let x_err = repeat(0.3f32);
 	let y_err = repeat(5.0f32);
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
 
@@ -43,9 +39,9 @@ fn example(c: Common)
 	.lines(x, y1, &[Caption("(x - 4)^2 - 5"), LineWidth(1.5), Color("black")])
 	.y_error_lines(x, y2, repeat(1.0f32), &[Caption("(x - 4)^2 + 5"), LineWidth(1.5), Color("red")])
 	.lines_points(x, y3, &[Caption("x - 4"), PointSymbol('t'), LineWidth(1.5), LineStyle(Dash), Color("#11ff11")]);
-	
+
 	c.show(&mut fg, "fg1.1.gnuplot");
-	
+
 	if !c.no_show
 	{
 		fg.set_terminal("pdfcairo", "fg1.1.pdf");
@@ -56,22 +52,22 @@ fn example(c: Common)
 
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_pos_grid(2, 2, 0)
 	.lines(x, y1, &[Caption("Lines"), LineWidth(3.0), Color("violet")])
 	.set_title("Plot1", &[]);
-	
+
 	fg.axes2d()
 	.set_pos_grid(2, 1, 1)
 	.points(x, y2, &[Caption("Points"), PointSymbol('D'), Color("#ffaa77"), PointSize(2.0)])
 	.set_title("Plot2", &[]);
-	
+
 	c.show(&mut fg, "fg1.2.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.lines(x, y1, &[Caption("Lines"), LineWidth(3.0), Color("violet")]);
 
@@ -83,7 +79,7 @@ fn example(c: Common)
 	.set_title("Inset", &[]);
 
 	c.show(&mut fg, "fg1.3.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
 
@@ -93,7 +89,7 @@ fn example(c: Common)
 	.set_y_label("This axis is manually scaled on the low end", &[]);
 
 	c.show(&mut fg, "fg1.4.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
 
@@ -103,7 +99,7 @@ fn example(c: Common)
 	.set_title("Errors", &[]);
 
 	c.show(&mut fg, "fg1.5.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
 
@@ -120,10 +116,10 @@ fn example(c: Common)
 	.set_legend(Graph(0.5), Graph(-0.2), &[Horizontal, Placement(AlignCenter, AlignTop), Title("Legend Title")], &[TextAlign(AlignRight)]);
 
 	c.show(&mut fg, "fg1.6.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_pos(0.1, 0.1)
 	.set_size(0.8, 0.8)
@@ -134,7 +130,7 @@ fn example(c: Common)
 	.set_y_label("Y Label", &[Rotate(0.0)])
 	.set_title("Goings nuts with the formatting", &[Font("Times", 24.0), TextOffset(-10.0, 0.5)])
 	.label("Intersection", Axis(2.208), Axis(-1.791), &[MarkerSymbol('*'), TextAlign(AlignCenter), TextOffset(0.0, -1.0), MarkerColor("red"), MarkerSize(2.0)]);
-	
+
 	c.show(&mut fg, "fg1.7.gnuplot");
 }
 

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -1,9 +1,4 @@
 // This file is released into Public Domain.
-#![feature(unboxed_closures)]
-#![feature(collections)]
-#![feature(rustc_private)]
-#![feature(step_by)]
-
 extern crate gnuplot;
 
 use std::iter::repeat;
@@ -19,18 +14,18 @@ fn example(c: Common)
 	let x = x.iter2();
 	let y1: Vec<i32> = x.map(|&v| { v * v }).collect();
 	let y1 = y1.iter2();
-	
+
 	let x2 = &[1i32, 4, 5];
 	let x2 = x2.iter2();
 	let y2: Vec<i32> = x2.map(|&v| { v * v }).collect();
 	let y2 = y2.iter2();
 	let w = repeat(0.5f32);
-	
+
 	let x3 = &[-3i32, -2, -1, 0, 2, 3];
 	let x3 = x3.iter2();
 	let y3: Vec<i32> = x3.map(|&v| { v * v * v }).collect();
 	let y3 = y3.iter2();
-	
+
 	let zw = 16;
 	let zh = 16;
 	let mut z1 = Vec::with_capacity((zw * zh) as usize);
@@ -43,44 +38,44 @@ fn example(c: Common)
 			z1.push(x + y);
 		}
 	}
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_title("Arrows", &[])
 	.lines(x, y1, &[LineWidth(3.0), Color("brown"), LineStyle(DotDash)])
 	.arrow(Graph(0.5), Graph(1.0), Axis(1.0), Axis(1.0), &[ArrowType(Filled), ArrowSize(0.1), LineStyle(DotDotDash), LineWidth(2.0), Color("red")])
 	.arrow(Graph(0.5), Graph(1.0), Axis(3.0), Axis(9.0), &[ArrowType(Open), Color("green")]);
-	
+
 	c.show(&mut fg, "fg2.1.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_title("Boxes", &[])
 	.boxes(x2, y2, &[LineWidth(2.0), Color("cyan"), BorderColor("blue"), LineStyle(DotDash)])
 	.boxes_set_width(x, y1, w, &[LineWidth(2.0), Color("gray"), BorderColor("black")]);
-	
+
 	c.show(&mut fg, "fg2.2.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_title("Axis Ticks", &[])
 	.lines(x3, y3, &[LineWidth(2.0), Color("blue")])
-	.set_x_ticks_custom((0..10).step_by(2).map(|x| Major(x as f32, Fix("%.2f ms".to_string())))
-	                    .chain((1..10).step_by(2).map(|x| Minor(x as f32))).chain(Some(Major(-2.1f32, Fix("%.2f ms".to_string()))).into_iter()),
+	.set_x_ticks_custom((0..5).map(|i| 2 * i).map(|x| Major(x as f32, Fix("%.2f ms".to_string())))
+	                    .chain((0..5).map(|i| 2 * i + 1).map(|x| Minor(x as f32))).chain(Some(Major(-2.1f32, Fix("%.2f ms".to_string()))).into_iter()),
 						&[MajorScale(2.0), MinorScale(0.5), OnAxis(true)], &[TextColor("blue"), TextAlign(AlignCenter)])
 	.set_y_ticks(Some((Fix(2.0), 1)), &[Mirror(false)], &[]);
-	
+
 	c.show(&mut fg, "fg2.3.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_title("Border, Axes", &[])
 	.set_border(true, &[Left, Bottom], &[LineWidth(2.0)])
@@ -89,18 +84,18 @@ fn example(c: Common)
 	.lines(x3, y3, &[LineWidth(2.0), Color("blue")])
 	.set_x_axis(true, &[LineWidth(2.0), LineStyle(DotDotDash)])
 	.set_y_axis(true, &[LineWidth(2.0), Color("red")]);
-	
+
 	c.show(&mut fg, "fg2.4.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes2d()
 	.set_title("Image", &[])
 	.image(z1.iter(), zw, zh, Some((-4.0, -4.0, 4.0, 4.0)), &[]);
-	
+
 	c.show(&mut fg, "fg2.5.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
 
@@ -110,7 +105,7 @@ fn example(c: Common)
 	.set_x_ticks(None, &[], &[])
 	.set_y_ticks(None, &[], &[])
 	.image(z1.iter(), zw, zh, Some((-4.0, -4.0, 4.0, 4.0)), &[]);
-	
+
 	c.show(&mut fg, "fg2.6.gnuplot");
 
 	let x4 = &[1f32, 10.0, 100.0];

--- a/examples/example3.rs
+++ b/examples/example3.rs
@@ -1,8 +1,4 @@
 // This file is released into Public Domain.
-#![feature(unboxed_closures)]
-#![feature(collections)]
-#![feature(rustc_private)]
-
 extern crate gnuplot;
 
 use std::vec::Vec;
@@ -26,10 +22,10 @@ fn example(c: Common)
 			z1.push(x.cos() * y.cos() / ((x*x + y*y).sqrt() + 1.0));
 		}
 	}
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes3d()
 	.set_title("Surface", &[])
 	.surface(z1.iter(), w, h, Some((-4.0, -4.0, 4.0, 4.0)), &[])
@@ -39,7 +35,7 @@ fn example(c: Common)
 	.set_z_range(Fix(-1.0), Fix(1.0))
 	.set_z_ticks(Some((Fix(1.0), 1)), &[Mirror(false)], &[])
 	.set_view(45.0, 45.0);
-	
+
 	c.show(&mut fg, "fg3.1.gnuplot");
 
 	let mut fg = Figure::new();
@@ -51,12 +47,12 @@ fn example(c: Common)
 	.set_x_label("X", &[])
 	.set_y_label("Y", &[])
 	.set_view_map();
-	
+
 	c.show(&mut fg, "fg3.2.gnuplot");
-	
+
 	let mut fg = Figure::new();
 	c.set_term(&mut fg);
-	
+
 	fg.axes3d()
 	.set_pos_grid(2, 2, 0)
 	.set_title("Base", &[])
@@ -77,14 +73,14 @@ fn example(c: Common)
 	.show_contours(true, true, Linear, Fix("%f"), Fix(1))
 	.surface(z1.iter(), w, h, Some((-4.0, -4.0, 4.0, 4.0)), &[])
 	.set_view(45.0, 45.0);
-	
+
 	fg.axes3d()
 	.set_pos_grid(2, 2, 3)
 	.set_title("Custom Levels", &[])
 	.show_contours_custom(true, false, Linear, Fix(""), Some(0f32).iter())
 	.surface(z1.iter(), w, h, Some((-4.0, -4.0, 4.0, 4.0)), &[])
 	.set_view(45.0, 45.0);
-	
+
 	c.show(&mut fg, "fg3.3.gnuplot");
 }
 

--- a/examples/example4.rs
+++ b/examples/example4.rs
@@ -1,8 +1,4 @@
 // This file is released into Public Domain.
-#![feature(unboxed_closures)]
-#![feature(collections)]
-#![feature(rustc_private)]
-
 extern crate gnuplot;
 
 use gnuplot::*;

--- a/src/axes2d.rs
+++ b/src/axes2d.rs
@@ -283,14 +283,14 @@ impl Axes2D
 
 	/// Plot a 2D scatter-plot with lines connecting each data point
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y` - Iterator for the y values
+	/// * `x` - x values
+	/// * `y` - y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `LineWidth` - Sets the width of the line
 	///     * `LineStyle` - Sets the style of the line
 	///     * `Color` - Sets the color
-	pub fn lines<'l, Tx: DataType, X: Iterator<Item = Tx>, Ty: DataType, Y: Iterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
+	pub fn lines<'l, Tx: DataType, X: IntoIterator<Item = Tx>, Ty: DataType, Y: IntoIterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot2(Lines, x, y, options);
 		self
@@ -298,14 +298,14 @@ impl Axes2D
 
 	/// Plot a 2D scatter-plot with a point standing in for each data point
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y` - Iterator for the y values
+	/// * `x` - x values
+	/// * `y` - y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `PointSymbol` - Sets symbol for each point
 	///     * `PointSize` - Sets the size of each point
 	///     * `Color` - Sets the color
-	pub fn points<'l, Tx: DataType, X: Iterator<Item = Tx>, Ty: DataType, Y: Iterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
+	pub fn points<'l, Tx: DataType, X: IntoIterator<Item = Tx>, Ty: DataType, Y: IntoIterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot2(Points, x, y, options);
 		self
@@ -313,10 +313,10 @@ impl Axes2D
 
 	/// A combination of lines and points methods (drawn in that order).
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y` - Iterator for the y values
+	/// * `x` - x values
+	/// * `y` - y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element
-	pub fn lines_points<'l, Tx: DataType, X: Iterator<Item = Tx>, Ty: DataType, Y: Iterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
+	pub fn lines_points<'l, Tx: DataType, X: IntoIterator<Item = Tx>, Ty: DataType, Y: IntoIterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot2(LinesPoints, x, y, options);
 		self
@@ -325,9 +325,9 @@ impl Axes2D
 	/// Plot a 2D scatter-plot with a point standing in for each data point and lines connecting each data point.
 	/// Additionally, error bars are attached to each data point in the X direction.
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y` - Iterator for the y valuess
-	/// * `x_error` - Iterator for the error associated with the x value
+	/// * `x` - x values
+	/// * `y` - y valuess
+	/// * `x_error` - Errors associated with the x value
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `PointSymbol` - Sets symbol for each point
@@ -336,9 +336,9 @@ impl Axes2D
 	///     * `LineStyle` - Sets the style of the line
 	///     * `Color` - Sets the color
 	pub fn x_error_lines<'l,
-	                   Tx: DataType, X: Iterator<Item = Tx>,
-	                   Ty: DataType, Y: Iterator<Item = Ty>,
-	                   Txe: DataType, XE: Iterator<Item = Txe>>(&'l mut self, x: X, y: Y, x_error: XE, options: &[PlotOption]) -> &'l mut Axes2D
+	                   Tx: DataType, X: IntoIterator<Item = Tx>,
+	                   Ty: DataType, Y: IntoIterator<Item = Ty>,
+	                   Txe: DataType, XE: IntoIterator<Item = Txe>>(&'l mut self, x: X, y: Y, x_error: XE, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot3(XErrorLines, x, y, x_error, options);
 		self
@@ -347,9 +347,9 @@ impl Axes2D
 	/// Plot a 2D scatter-plot with a point standing in for each data point and lines connecting each data point.
 	/// Additionally, error bars are attached to each data point in the Y direction.
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y` - Iterator for the y values
-	/// * `y_error` - Iterator for the error associated with the y values
+	/// * `x` - x values
+	/// * `y` - y values
+	/// * `y_error` - Errors associated with the y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `PointSymbol` - Sets symbol for each point
@@ -358,9 +358,9 @@ impl Axes2D
 	///     * `LineStyle` - Sets the style of the line
 	///     * `Color` - Sets the color
 	pub fn y_error_lines<'l,
-	                   Tx: DataType, X: Iterator<Item = Tx>,
-	                   Ty: DataType, Y: Iterator<Item = Ty>,
-	                   Tye: DataType, YE: Iterator<Item = Tye>>(&'l mut self, x: X, y: Y, y_error: YE, options: &[PlotOption]) -> &'l mut Axes2D
+	                   Tx: DataType, X: IntoIterator<Item = Tx>,
+	                   Ty: DataType, Y: IntoIterator<Item = Ty>,
+	                   Tye: DataType, YE: IntoIterator<Item = Tye>>(&'l mut self, x: X, y: Y, y_error: YE, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot3(YErrorLines, x, y, y_error, options);
 		self
@@ -370,18 +370,18 @@ impl Axes2D
 	/// `FillRegion` plot option can be used to control what happens when the curves intersect. If set to Above, then the `y_lo < y_hi` region is filled.
 	/// If set to Below, then the `y_lo > y_hi` region is filled. Otherwise both regions are filled.
 	/// # Arguments
-	/// * `x` - Iterator for the x values
-	/// * `y_lo` - Iterator for the bottom y values
-	/// * `y_hi` - Iterator for the top y values
+	/// * `x` - x values
+	/// * `y_lo` - Bottom y values
+	/// * `y_hi` - Top y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `FillRegion` - Specifies the region between the two curves to fill
 	///     * `Color` - Sets the color of the filled region
 	///     * `FillAlpha` - Sets the transparency of the filled region
 	pub fn fill_between<'l,
-	                   Tx: DataType, X: Iterator<Item = Tx>,
-	                   Tyl: DataType, YL: Iterator<Item = Tyl>,
-	                   Tyh: DataType, YH: Iterator<Item = Tyh>>(&'l mut self, x: X, y_lo: YL, y_hi: YH, options: &[PlotOption]) -> &'l mut Axes2D
+	                   Tx: DataType, X: IntoIterator<Item = Tx>,
+	                   Tyl: DataType, YL: IntoIterator<Item = Tyl>,
+	                   Tyh: DataType, YH: IntoIterator<Item = Tyh>>(&'l mut self, x: X, y_lo: YL, y_hi: YH, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot3(FillBetween, x, y_lo, y_hi, options);
 		self
@@ -390,8 +390,8 @@ impl Axes2D
 	/// Plot a 2D scatter-plot using boxes of automatic width. Box widths are set so that there are no gaps between successive boxes (i.e. each box may have a different width).
 	/// Boxes start at the x-axis and go towards the y value of the datapoint.
 	/// # Arguments
-	/// * `x` - Iterator for the x values (center of the box)
-	/// * `y` - Iterator for the y values
+	/// * `x` - x values (center of the box)
+	/// * `y` - y values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `LineWidth` - Sets the width of the border
@@ -399,7 +399,7 @@ impl Axes2D
 	///     * `BorderColor` - Sets the color of the border
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
-	pub fn boxes<'l, Tx: DataType, X: Iterator<Item = Tx>, Ty: DataType, Y: Iterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
+	pub fn boxes<'l, Tx: DataType, X: IntoIterator<Item = Tx>, Ty: DataType, Y: IntoIterator<Item = Ty>>(&'l mut self, x: X, y: Y, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot2(Boxes, x, y, options);
 		self
@@ -408,9 +408,9 @@ impl Axes2D
 	/// Plot a 2D scatter-plot using boxes of set (per box) width.
 	/// Boxes start at the x-axis and go towards the y value of the datapoint.
 	/// # Arguments
-	/// * `x` - Iterator for the x values (center of the box)
-	/// * `y` - Iterator for the y values
-	/// * `w` - Iterator for the box width values
+	/// * `x` - x values (center of the box)
+	/// * `y` - y values
+	/// * `w` - Box width values
 	/// * `options` - Array of PlotOption controlling the appearance of the plot element. The relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	///     * `LineWidth` - Sets the width of the border
@@ -420,11 +420,11 @@ impl Axes2D
 	///     * `FillAlpha` - Sets the transparency of the box fill
 	pub fn boxes_set_width<'l,
 	                      Tx: DataType,
-	                      X: Iterator<Item = Tx>,
+	                      X: IntoIterator<Item = Tx>,
 	                      Ty: DataType,
-	                      Y: Iterator<Item = Ty>,
+	                      Y: IntoIterator<Item = Ty>,
 	                      Tw: DataType,
-	                      W: Iterator<Item = Tw>>(&'l mut self, x: X, y: Y, w: W, options: &[PlotOption]) -> &'l mut Axes2D
+	                      W: IntoIterator<Item = Tw>>(&'l mut self, x: X, y: Y, w: W, options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot3(Boxes, x, y, w, options);
 		self
@@ -443,7 +443,7 @@ impl Axes2D
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	pub fn image<'l,
 	              T: DataType,
-	              X: Iterator<Item = T>>(&'l mut self, mat: X, num_rows: usize, num_cols: usize, dimensions: Option<(f64, f64, f64, f64)>,
+	              X: IntoIterator<Item = T>>(&'l mut self, mat: X, num_rows: usize, num_cols: usize, dimensions: Option<(f64, f64, f64, f64)>,
 	                              options: &[PlotOption]) -> &'l mut Axes2D
 	{
 		self.common.plot_matrix(Image, false, mat, num_rows, num_cols, dimensions, options);

--- a/src/axes3d.rs
+++ b/src/axes3d.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 by SiegeLord
-// 
+//
 // All rights reserved. Distributed under LGPL 3.0. For full terms see the file LICENSE.
 
 use std::io::Write;
@@ -35,7 +35,7 @@ impl Axes3D
 	///                  By default this will be `(0, 0)` and `(num_rows - 1, num_cols - 1)`.
 	/// * `options` - Array of PlotOption controlling the appearance of the surface. Relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
-	pub fn surface<'l, T: DataType, X: Iterator<Item = T>>(&'l mut self, mat: X, num_rows: usize, num_cols: usize, dimensions: Option<(f64, f64, f64, f64)>, options: &[PlotOption]) -> &'l mut Axes3D
+	pub fn surface<'l, T: DataType, X: IntoIterator<Item = T>>(&'l mut self, mat: X, num_rows: usize, num_cols: usize, dimensions: Option<(f64, f64, f64, f64)>, options: &[PlotOption]) -> &'l mut Axes3D
 	{
 		self.common.plot_matrix(Pm3D, true, mat, num_rows, num_cols, dimensions, options);
 		self
@@ -83,7 +83,7 @@ impl Axes3D
 	}
 
 	/// Like `set_x_ticks_custom` but for the the Y axis.
-	pub fn set_z_ticks_custom<'l, T: DataType, TL: Iterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Axes3D
+	pub fn set_z_ticks_custom<'l, T: DataType, TL: IntoIterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Axes3D
 	{
 		self.z_axis.set_ticks_custom(ticks, tick_options, label_options);
 		self
@@ -139,16 +139,16 @@ impl Axes3D
 	/// * `style` - Style of the contours
 	/// * `label` - Auto sets the label automatically and enables the legend, Fix() allows you specify a format string (using C style formatting),
 	///             otherwise an empty string disables the legend and labels.
-	/// * `levels` - Iterator for a set of levels.
+	/// * `levels` - A set of levels.
 	pub fn show_contours_custom<'l, T: DataType,
-	                            TC: Iterator<Item = T>>(&'l mut self, base: bool, surface: bool,
+	                            TC: IntoIterator<Item = T>>(&'l mut self, base: bool, surface: bool,
 	                                             style: ContourStyle, label: AutoOption<&str>, levels: TC) -> &'l mut Axes3D
 	{
 		self.contour_base = base;
 		self.contour_surface = surface;
 		self.contour_style = style;
 		self.contour_auto = Auto;
-		self.contour_levels = Some(levels.map(|l| l.get()).collect());
+		self.contour_levels = Some(levels.into_iter().map(|l| l.get()).collect());
 		self.contour_label = label.map(|l| l.to_string());
 		self
 	}
@@ -195,7 +195,7 @@ impl Axes3DPrivate for Axes3D
 	fn write_out(&self, w: &mut Writer)
 	{
 		fn clamp<T: PartialOrd>(val: T, min: T, max: T) -> T
-		{			
+		{
 			if val < min
 			{
 				min
@@ -209,12 +209,12 @@ impl Axes3DPrivate for Axes3D
 				val
 			}
 		}
-		
+
 		if self.common.elems.len() == 0
 		{
 			return;
 		}
-		
+
 		if self.contour_base || self.contour_surface
 		{
 			write!(w, "set contour ");
@@ -226,7 +226,7 @@ impl Axes3DPrivate for Axes3D
 				_ => unreachable!()
 			});
 			write!(w, "\n");
-			
+
 			match self.contour_label
 			{
 				Auto => writeln!(w, "set clabel"),
@@ -239,14 +239,14 @@ impl Axes3DPrivate for Axes3D
 					writeln!(w, r#"set clabel "{}""#, s)
 				}
 			};
-			
+
 			fn set_cntrparam<F: FnOnce(&mut Writer)>(w: &mut Writer, wr: F)
 			{
 				write!(w, "set cntrparam ");
 				wr(w);
 				write!(w, "\n");
 			}
-			
+
 			set_cntrparam(w, |w|
 			{
 				write!(w, "{}", match self.contour_style
@@ -271,7 +271,7 @@ impl Axes3DPrivate for Axes3D
 					write!(w, "points {}", clamp(pt, 2, 100));
 				});
 			});
-			
+
 			set_cntrparam(w, |w|
 			{
 				let ord = match self.contour_style
@@ -291,7 +291,7 @@ impl Axes3DPrivate for Axes3D
 				write!(w, "levels ");
 				match self.contour_levels
 				{
-					Some(ref ls) => 
+					Some(ref ls) =>
 					{
 						write!(w, "discrete ");
 						let mut left = ls.len();
@@ -305,7 +305,7 @@ impl Axes3DPrivate for Axes3D
 							left -= 1;
 						}
 					},
-					None => 
+					None =>
 					{
 						match self.contour_auto
 						{

--- a/src/axes_common.rs
+++ b/src/axes_common.rs
@@ -266,7 +266,7 @@ impl AxisData
 			max: Auto,
 		}
 	}
-	
+
 	pub fn write_out_commands(&self, w: &mut Writer)
 	{
 		let log = match self.log_base
@@ -320,11 +320,11 @@ impl AxisData
 			Auto => w.write_str("*")
 		};
 		w.write_str("]\n");
-		
+
 		w.write_all(&self.ticks_buf[..]);
 	}
-	
-	pub fn set_ticks_custom<T: DataType, TL: Iterator<Item = Tick<T>>>(&mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption])
+
+	pub fn set_ticks_custom<T: DataType, TL: IntoIterator<Item = Tick<T>>>(&mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption])
 	{
 		// Set to 0 so that we don't get any non-custom ticks
 		self.mticks = 0;
@@ -440,7 +440,7 @@ impl AxisData
 	pub fn set_ticks(&mut self, tick_placement: Option<(AutoOption<f64>, u32)>, tick_options: &[TickOption], label_options: &[LabelOption])
 	{
 		self.ticks_buf.truncate(0);
-			
+
 		self.mticks = match tick_placement
 		{
 			Some((incr, mticks)) =>
@@ -599,9 +599,9 @@ impl AxesCommonData
 			None => ()
 		}
 	}
-	
-	pub fn plot2<T1: DataType, X1: Iterator<Item = T1>,
-	             T2: DataType, X2: Iterator<Item = T2>>(&mut self, plot_type: PlotType, x1: X1, x2: X2, options: &[PlotOption])
+
+	pub fn plot2<T1: DataType, X1: IntoIterator<Item = T1>,
+	             T2: DataType, X2: IntoIterator<Item = T2>>(&mut self, plot_type: PlotType, x1: X1, x2: X2, options: &[PlotOption])
 	{
 		let l = self.elems.len();
 		self.elems.push(PlotElement::new());
@@ -609,7 +609,7 @@ impl AxesCommonData
 
 		{
 			let data = &mut self.elems[l].data;
-			for (x1, x2) in x1.zip(x2)
+			for (x1, x2) in x1.into_iter().zip(x2.into_iter())
 			{
 				data.write_data(x1);
 				data.write_data(x2);
@@ -620,9 +620,9 @@ impl AxesCommonData
 		self.write_common_commands(l, num_rows, 2, plot_type, Record, false, options);
 	}
 
-	pub fn plot3<T1: DataType, X1: Iterator<Item = T1>,
-			     T2: DataType, X2: Iterator<Item = T2>,
-			     T3: DataType, X3: Iterator<Item = T3>>(&mut self, plot_type: PlotType, x1: X1, x2: X2, x3: X3, options: &[PlotOption])
+	pub fn plot3<T1: DataType, X1: IntoIterator<Item = T1>,
+			     T2: DataType, X2: IntoIterator<Item = T2>,
+			     T3: DataType, X3: IntoIterator<Item = T3>>(&mut self, plot_type: PlotType, x1: X1, x2: X2, x3: X3, options: &[PlotOption])
 	{
 		let l = self.elems.len();
 		self.elems.push(PlotElement::new());
@@ -630,7 +630,7 @@ impl AxesCommonData
 
 		{
 			let data = &mut self.elems[l].data;
-			for ((x1, x2), x3) in x1.zip(x2).zip(x3)
+			for ((x1, x2), x3) in x1.into_iter().zip(x2.into_iter()).zip(x3.into_iter())
 			{
 				data.write_data(x1);
 				data.write_data(x2);
@@ -642,12 +642,12 @@ impl AxesCommonData
 		self.write_common_commands(l, num_rows, 3, plot_type, Record, false, options);
 	}
 
-	pub fn plot_matrix<T: DataType, X: Iterator<Item = T>>(&mut self, plot_type: PlotType, is_3d: bool, mat: X, num_rows: usize, num_cols: usize,
+	pub fn plot_matrix<T: DataType, X: IntoIterator<Item = T>>(&mut self, plot_type: PlotType, is_3d: bool, mat: X, num_rows: usize, num_cols: usize,
 	                                                dimensions: Option<(f64, f64, f64, f64)>, options: &[PlotOption])
 	{
 		let l = self.elems.len();
 		self.elems.push(PlotElement::new());
-		
+
 		{
 			let mut count = 0;
 			let data = &mut self.elems[l].data;
@@ -656,7 +656,7 @@ impl AxesCommonData
 				data.write_data(x);
 				count += 1;
 			}
-			
+
 			if count < num_rows * num_cols
 			{
 				for _ in 0..num_rows * num_cols - count
@@ -666,7 +666,7 @@ impl AxesCommonData
 				}
 			}
 		}
-		
+
 		let source_type = match dimensions
 		{
 			Some((x1, y1, x2, y2)) => SizedArray(x1, y1, x2, y2),
@@ -681,10 +681,10 @@ impl AxesCommonData
 		let args = &mut self.elems[elem_idx].args as &mut Writer;
 		match source_type
 		{
-			Record => 
+			Record =>
 			{
 				write!(args, r#" "-" binary endian=little record={} format="%float64" using "#, num_rows);
-			
+
 				let mut col_idx = 1;
 				while col_idx < num_cols + 1
 				{
@@ -699,7 +699,7 @@ impl AxesCommonData
 			_ =>
 			{
 				write!(args, r#" "-" binary endian=little array=({},{}) format="%float64" "#, num_cols, num_rows);
-				
+
 				match source_type
 				{
 					SizedArray(x1, y1, x2, y2) =>
@@ -712,7 +712,7 @@ impl AxesCommonData
 						{
 							(x1, x2)
 						};
-						
+
 						let (y1, y2) = if y1 > y2
 						{
 							(y2, y1)
@@ -1085,7 +1085,7 @@ pub trait AxesCommon : AxesCommonPrivate
 	///
 	/// # Arguments
 	///
-	/// * `ticks` - Iterator specifying the locations and labels of the added ticks.
+	/// * `ticks` - The locations and labels of the added ticks.
 	///     The label can contain a single C printf style floating point formatting specifier which will be replaced by the
 	///     location of the tic.
 	/// * `tick_options` - Array of TickOption controlling the appearance of the ticks
@@ -1095,21 +1095,21 @@ pub trait AxesCommon : AxesCommonPrivate
 	///      * `TextColor` - Specifies the color of the label
 	///      * `Rotate` - Specifies the rotation of the label
 	///      * `Align` - Specifies how to align the label
-	fn set_x_ticks_custom<'l, T: DataType, TL: Iterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
+	fn set_x_ticks_custom<'l, T: DataType, TL: IntoIterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
 	{
 		self.get_common_data_mut().x_axis.set_ticks_custom(ticks, tick_options, label_options);
 		self
 	}
 
 	/// Like `set_x_ticks_custom` but for the the Y axis.
-	fn set_y_ticks_custom<'l, T: DataType, TL: Iterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
+	fn set_y_ticks_custom<'l, T: DataType, TL: IntoIterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
 	{
 		self.get_common_data_mut().y_axis.set_ticks_custom(ticks, tick_options, label_options);
 		self
 	}
 
 	/// Like `set_x_ticks_custom` but for the the color bar axis.
-	fn set_cb_ticks_custom<'l, T: DataType, TL: Iterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
+	fn set_cb_ticks_custom<'l, T: DataType, TL: IntoIterator<Item = Tick<T>>>(&'l mut self, ticks: TL, tick_options: &[TickOption], label_options: &[LabelOption]) -> &'l mut Self
 	{
 		self.get_common_data_mut().cb_axis.set_ticks_custom(ticks, tick_options, label_options);
 		self
@@ -1219,7 +1219,7 @@ pub trait AxesCommon : AxesCommonPrivate
 	///
 	/// # Arguments
 	/// * `palette_generator` - The palette generator
-	fn set_custom_palette<T: Iterator<Item = (f32, f32, f32, f32)>>(&mut self, palette_generator: T) -> &mut Self
+	fn set_custom_palette<T: IntoIterator<Item = (f32, f32, f32, f32)>>(&mut self, palette_generator: T) -> &mut Self
 	{
 		{
 			let c = &mut self.get_common_data_mut().commands as &mut Writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 by SiegeLord
-// 
+//
 // All rights reserved. Distributed under LGPL 3.0. For full terms see the file LICENSE.
 
 #![crate_name="gnuplot"]
@@ -18,11 +18,11 @@ A simple gnuplot controller.
 # fn main() {
 use gnuplot::{Figure, Caption, Color};
 
-let x = &[0u32, 1, 2];
-let y = &[3u32, 4, 5];
+let x = [0u32, 1, 2];
+let y = [3u32, 4, 5];
 let mut fg = Figure::new();
 fg.axes2d()
-.lines(x.iter(), y.iter(), &[Caption("A line"), Color("black")]);
+.lines(&x, &y, &[Caption("A line"), Color("black")]);
 fg.show();
 # }
 ~~~
@@ -44,6 +44,6 @@ mod axes3d;
 mod axes_common;
 mod writer;
 mod figure;
-mod options; 
+mod options;
 mod datatype;
 mod coordinates;


### PR DESCRIPTION
Hi,

This patch relaxes the input type of all methods from `Iterator<_>` to `IntoIterator<_>`. Since every `Iterator` implements `IntoIterator`, this does not break any old code. On the other hand, it allows for a more ergonomic code:

```rust
let x = [0i32, 1, 2];
fg.axes2d().lines(&x, ...);
```
and such.

I had to update the examples since they do not build on nightly anymore. I have removed all unstable features so the examples now build on the stable branch.