### PR TITLE
Reverse x, y, z axes

### DIFF
--- a/src/axes3d.rs
+++ b/src/axes3d.rs
@@ -100,6 +100,14 @@ impl Axes3D
 		self
 	}
 
+	/// Sets z axis to reverse.
+	pub fn set_z_reverse<'l>(&'l mut self) -> &'l mut Self
+	{
+		self.z_axis.set_reverse();
+		self
+	}
+
+
 	/// Sets the Z axis be logarithmic. Note that the range must be non-negative for this to be valid.
 	///
 	/// # Arguments

--- a/src/axes3d.rs
+++ b/src/axes3d.rs
@@ -101,9 +101,9 @@ impl Axes3D
 	}
 
 	/// Sets z axis to reverse.
-	pub fn set_z_reverse<'l>(&'l mut self) -> &'l mut Self
+	pub fn set_z_reverse<'l>(&'l mut self, reverse: bool) -> &'l mut Self
 	{
-		self.z_axis.set_reverse();
+		self.z_axis.set_reverse(reverse);
 		self
 	}
 

--- a/src/axes_common.rs
+++ b/src/axes_common.rs
@@ -250,6 +250,7 @@ pub struct AxisData
 	pub axis: TickAxis,
 	pub min: AutoOption<f64>,
 	pub max: AutoOption<f64>,
+	pub reverse: bool,
 }
 
 impl AxisData
@@ -264,6 +265,7 @@ impl AxisData
 			axis: axis,
 			min: Auto,
 			max: Auto,
+			reverse: false,
 		}
 	}
 
@@ -319,7 +321,13 @@ impl AxisData
 			Fix(v) => write!(w, "{:.12e}", v),
 			Auto => w.write_str("*")
 		};
-		w.write_str("]\n");
+        if self.reverse
+        {
+            w.write_str("] reverse\n");
+        }
+        else {
+            w.write_str("]\n");
+        }
 
 		w.write_all(&self.ticks_buf[..]);
 	}
@@ -490,6 +498,11 @@ impl AxisData
 	{
 		self.log_base = base;
 	}
+
+    pub fn set_reverse(&mut self)
+    {
+        self.reverse = true;
+    }
 }
 
 pub struct AxesCommonData
@@ -1134,6 +1147,20 @@ pub trait AxesCommon : AxesCommonPrivate
 	fn set_y_range<'l>(&'l mut self, min: AutoOption<f64>, max: AutoOption<f64>) -> &'l mut Self
 	{
 		self.get_common_data_mut().y_axis.set_range(min, max);
+		self
+	}
+
+	/// Sets X axis to reverse.
+	fn set_x_reverse<'l>(&'l mut self) -> &'l mut Self
+	{
+		self.get_common_data_mut().x_axis.set_reverse();
+		self
+	}
+
+	/// Sets Y axis to reverse.
+	fn set_y_reverse<'l>(&'l mut self) -> &'l mut Self
+	{
+		self.get_common_data_mut().y_axis.set_reverse();
 		self
 	}
 

--- a/src/axes_common.rs
+++ b/src/axes_common.rs
@@ -321,13 +321,13 @@ impl AxisData
 			Fix(v) => write!(w, "{:.12e}", v),
 			Auto => w.write_str("*")
 		};
-        if self.reverse
-        {
-            w.write_str("] reverse\n");
-        }
-        else {
-            w.write_str("]\n");
-        }
+		if self.reverse
+		{
+			w.write_str("] reverse\n");
+		}
+		else {
+			w.write_str("]\n");
+		}
 
 		w.write_all(&self.ticks_buf[..]);
 	}
@@ -499,9 +499,9 @@ impl AxisData
 		self.log_base = base;
 	}
 
-    pub fn set_reverse(&mut self)
+    pub fn set_reverse(&mut self, reverse: bool)
     {
-        self.reverse = true;
+        self.reverse = reverse;
     }
 }
 
@@ -1151,16 +1151,20 @@ pub trait AxesCommon : AxesCommonPrivate
 	}
 
 	/// Sets X axis to reverse.
-	fn set_x_reverse<'l>(&'l mut self) -> &'l mut Self
+	/// # Arguments
+	/// * `reverse` - Boolean, true to reverse axis, false will not reverse
+	fn set_x_reverse<'l>(&'l mut self, reverse: bool) -> &'l mut Self
 	{
-		self.get_common_data_mut().x_axis.set_reverse();
+		self.get_common_data_mut().x_axis.set_reverse(reverse);
 		self
 	}
 
 	/// Sets Y axis to reverse.
-	fn set_y_reverse<'l>(&'l mut self) -> &'l mut Self
+	/// # Arguments
+	/// * `reverse` - Boolean, true to reverse axis, false will not reverse
+	fn set_y_reverse<'l>(&'l mut self, reverse: bool) -> &'l mut Self
 	{
-		self.get_common_data_mut().y_axis.set_reverse();
+		self.get_common_data_mut().y_axis.set_reverse(reverse);
 		self
 	}
 


### PR DESCRIPTION
In axes_common.rs:

- in struct `AxisData`, add field `reverse: bool`.
- in `AxisData::new()`, initialize struct with `reverse: false`.
- in `AxisData::write_out_commands()`, write `reverse`.
- add `AxisData::set_reverse()` method.
- in `trait AxesCommon : AxesCommonPrivate` add `set_x_reverse()` and
  `set_y_reverse()` methods.

In axes3d.rs:

- add method `set_z_reverse` to `Axes3D`.