### PR TITLE
Support setting margins of plots

### DIFF
--- a/src/axes2d.rs
+++ b/src/axes2d.rs
@@ -56,6 +56,30 @@ impl Axes2D
 		self
 	}
 
+	/// Sets the margins of the plot
+	///
+	/// # Arguments
+	///
+	/// * `margins` - The values of margins to be overrided. Specified as a fraction of the
+	///               full drawing area, ranging from 0 to 1
+	pub fn set_margins<'l>(&'l mut self, margins: &[MarginSide]) -> &'l mut Self
+	{
+		{
+			let c = &mut self.common.commands as &mut Writer;
+			for &s in margins.iter()
+			{
+				match s
+				{
+					MarginTop(frac) => writeln!(c, "set tmargin at screen {}", frac),
+					MarginBottom(frac) => writeln!(c, "set bmargin at screen {}", frac),
+					MarginLeft(frac) => writeln!(c, "set lmargin at screen {}", frac),
+					MarginRight(frac) => writeln!(c, "set rmargin at screen {}", frac),
+				};
+			}
+		}
+		self
+	}
+
 	fn set_axis_common<'l>(&'l mut self, axis: &str, show: bool, options: &[PlotOption<&str>]) -> &'l mut Self
 	{
 		{

--- a/src/options.rs
+++ b/src/options.rs
@@ -6,6 +6,7 @@ pub use self::AlignType::*;
 pub use self::ArrowheadType::*;
 pub use self::AutoOption::*;
 pub use self::BorderLocation2D::*;
+pub use self::MarginSide::*;
 pub use self::ContourStyle::*;
 pub use self::DashType::*;
 pub use self::FillRegionType::*;
@@ -297,6 +298,15 @@ pub enum BorderLocation2D
 	Left = 2,
 	Top = 4,
 	Right = 8,
+}
+
+/// Plot margins
+#[derive(Copy, Clone)]
+pub enum MarginSide {
+	MarginTop(f32),
+	MarginBottom(f32),
+	MarginLeft(f32),
+	MarginRight(f32),
 }
 
 /// Legend options


### PR DESCRIPTION
Hacked for my own needs, just make a PR in case they are of help.

I was generating small images (128x128), without any axis/tick/title/legend, just lines. The white margins look too wide in such small size. I didn't figure out how to reduce the margins with current API, so I implemented a new function in axes2d.rs.

This is my first time using gnuplot (just in search of a plotting tool in rust, and this seems to be the only viable option to me), and not sure if my usage is correct.