### PR TITLE
Use byteorder crate for writing f64 little endian

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,6 @@ path = "examples/dash_type.rs"
 
 name = "patterns"
 path = "examples/patterns.rs"
+
+[dependencies]
+byteorder = "1.3.1"

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,23 +2,16 @@
 //
 // All rights reserved. Distributed under LGPL 3.0. For full terms see the file LICENSE.
 
+use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{self, Write};
-use std::mem::transmute;
 
-pub trait Writer: Write
-{
-	fn write_str(&mut self, s: &str) -> Result<(), io::Error>
-	{
+pub trait Writer: Write {
+	fn write_str(&mut self, s: &str) -> Result<(), io::Error> {
 		self.write_all(s.as_bytes())
 	}
 
-	fn write_le_f64(&mut self, v: f64) -> Result<(), io::Error>
-	{
-		let vb: [u8; 8] = unsafe {
-			let v: u64 = transmute(v);
-			transmute(v.to_le())
-		};
-		self.write_all(&vb)
+	fn write_le_f64(&mut self, v: f64) -> Result<(), io::Error> {
+		self.write_f64::<LittleEndian>(v)
 	}
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,12 +5,15 @@
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{self, Write};
 
-pub trait Writer: Write {
-	fn write_str(&mut self, s: &str) -> Result<(), io::Error> {
+pub trait Writer: Write
+{
+	fn write_str(&mut self, s: &str) -> Result<(), io::Error>
+	{
 		self.write_all(s.as_bytes())
 	}
 
-	fn write_le_f64(&mut self, v: f64) -> Result<(), io::Error> {
+	fn write_le_f64(&mut self, v: f64) -> Result<(), io::Error>
+	{
 		self.write_f64::<LittleEndian>(v)
 	}
 }


### PR DESCRIPTION
This has two benefits:

* Extract some shared functionality to a centralized crate.
* Get rid of unsafe code.  (`byteorder`'s implementation does not use `unsafe`)

Closes #42, since this PR removes the only use of unsafe code in the library and dependencies.