### PR TITLE
Add enhanced text as a Figure option

### DIFF
--- a/src/figure.rs
+++ b/src/figure.rs
@@ -54,6 +54,7 @@ pub struct Figure
 {
 	axes: Vec<AxesVariant>,
 	terminal: String,
+	enhanced_text: bool,
 	output_file: String,
 	post_commands: String,
 	pre_commands: String,
@@ -78,6 +79,7 @@ impl Figure
 		Figure {
 			axes: Vec::new(),
 			terminal: "".into(),
+			enhanced_text: true,
 			output_file: "".into(),
 			gnuplot: RefCell::new(None),
 			post_commands: "".into(),
@@ -104,6 +106,12 @@ impl Figure
 	{
 		self.terminal = terminal.into();
 		self.output_file = output_file.into();
+		self
+	}
+
+	/// Set or unset text enhancements
+	pub fn set_enhanced_text<'l>(&'l mut self, enhanced: bool) -> &'l mut Figure {
+		self.enhanced_text = enhanced;
 		self
 	}
 
@@ -373,7 +381,7 @@ impl Figure
 		}
 
 		writeln!(w, "set termoption dashed");
-		writeln!(w, "set termoption enhanced");
+		writeln!(w, "set termoption {}", if self.enhanced_text { "enhanced" } else { "noenhanced" });
 		if self.axes.len() > 1
 		{
 			writeln!(w, "set multiplot");


### PR DESCRIPTION
Most of the time I don't need the [enhanced text mode](http://www.bersch.net/gnuplot-doc/enhanced-text-mode.html) that is enabled by default in `gnuplot` and hardcoded in this crate. As an example, If you try to use text with underscores in the plot (as I frequently do), those underscores act as control characters, changing the following character to subscript:

![file_with_underscores_0](https://user-images.githubusercontent.com/23461207/61331659-46017100-a7f0-11e9-88e1-57b9361cce1d.png)

By setting `noenhanced`, you don't have to escape your text:

```rust
let mut fig = Figure::new();
fig.set_enhanced_text(false);
```

![file_with_underscores_1](https://user-images.githubusercontent.com/23461207/61331809-a7c1db00-a7f0-11e9-83f8-37ac4f83a328.png)
