### PR TITLE
implement Drop for Figure

### DIFF
--- a/src/figure.rs
+++ b/src/figure.rs
@@ -603,6 +603,12 @@ impl Figure
 	}
 }
 
+impl Drop for Figure {
+	fn drop(&mut self) {
+		self.close();
+	}
+}
+
 #[test]
 fn flush_test()
 {


### PR DESCRIPTION
not doing a close() on a figure leaves an unterminated
zombie process in the operating system.