### PR TITLE
Handle "" properly in set_terminal

### DIFF
--- a/gnuplot/src/figure.rs
+++ b/gnuplot/src/figure.rs
@@ -142,10 +142,13 @@ impl Figure
 	pub fn set_terminal<'l>(&'l mut self, terminal: &str, output_file: &str) -> &'l mut Figure
 	{
 		self.terminal = terminal.into();
-		self.output_file = if output_file.len() > 0 {
-			Some(output_file.into())
-		} else {
+		self.output_file = if output_file.is_empty()
+		{
 			None
+		}
+		else
+		{
+			Some(output_file.into())
 		};
 		self
 	}

--- a/gnuplot/src/figure.rs
+++ b/gnuplot/src/figure.rs
@@ -142,7 +142,11 @@ impl Figure
 	pub fn set_terminal<'l>(&'l mut self, terminal: &str, output_file: &str) -> &'l mut Figure
 	{
 		self.terminal = terminal.into();
-		self.output_file = Some(output_file.into());
+		self.output_file = if output_file.len() > 0 {
+			Some(output_file.into())
+		} else {
+			None
+		};
 		self
 	}
 


### PR DESCRIPTION
As a side effect of fix #60, `output_file=""` must be converted into None for `Figure::echo` to work properly.