### PR TITLE
Gracefully handle empty datasets

### DIFF
--- a/gnuplot/src/axes_common.rs
+++ b/gnuplot/src/axes_common.rs
@@ -1449,6 +1449,7 @@ impl AxesCommonData
 		let mut first = true;
 		for e in self.elems.iter()
 		{
+			if e.num_rows == 0 { continue; }
 			if !first
 			{
 				write!(writer, ",");


### PR DESCRIPTION
In various situations, the iterator providing the coordinates may be empty.  As a toy example
```rust
use gnuplot::Figure;

fn main() -> eyre::Result<()> {
    let mut fg = Figure::new();
    let ax = fg.axes2d();
    ax.lines(&[1., 2.], &[1., 2.], &[]);
    let x: [f64; 0] = [];
    let y: [f64; 0] = [];
    ax.points(&x, &y, &[]);
    fg.show_and_keep_running()?;
    Ok(())
}
```
This library should handle that gracefully.