### PR TITLE
Clippy warning fixes

### DIFF
--- a/gnuplot/examples/variable_color.rs
+++ b/gnuplot/examples/variable_color.rs
@@ -37,8 +37,8 @@ fn example(c: Common)
 	let d5 = extract_col(4);
 	let d6 = extract_col(5);
 	let row_index: Vec<_> = (1..=d1.len() as u8).collect();
-	let by3 = |x| (((x % 3.0) + 1.0) / 6.0);
-	let by4 = |x| (((x % 4.0) + 1.0) / 7.0);
+	let by3 = |x| ((x % 3.0) + 1.0) / 6.0;
+	let by4 = |x| ((x % 4.0) + 1.0) / 7.0;
 
 	let argb_formula = |x: &f64| {
 		let a = 255.0 - 255.0 * (x - 5.5).abs() / 5.5;

--- a/gnuplot/src/axes2d.rs
+++ b/gnuplot/src/axes2d.rs
@@ -683,8 +683,8 @@ impl Axes2D
 	///     * `BorderColor` - Sets the color of the border
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
-	///		* `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
-	/// 		previously set box width, or be set to the spacing of the boxes
+	///     * `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
+	///       previously set box width, or be set to the spacing of the boxes
 	pub fn boxes<
 		'l,
 		Tx: DataType,
@@ -720,8 +720,8 @@ impl Axes2D
 	///     * `BorderColor` - Sets the color of the border
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
-	///		* `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
-	/// 		previously set box width, or be set to the spacing of the boxes
+	///     * `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
+	///       previously set box width, or be set to the spacing of the boxes
 	pub fn box_error_delta<
 		'l,
 		Tx: DataType,
@@ -763,8 +763,8 @@ impl Axes2D
 	///     * `BorderColor` - Sets the color of the border
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
-	///		* `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
-	/// 		previously set box width, or be set to the spacing of the boxes
+	///     * `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
+	///       previously set box width, or be set to the spacing of the boxes
 	pub fn box_error_low_high<
 		'l,
 		Tx: DataType,
@@ -813,8 +813,8 @@ impl Axes2D
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
 	///     * `WhiskerBars` - Sets the width of the whisker bars
-	///		* `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
-	/// 		previously set box width, or be set to the spacing of the boxes
+	///     * `BoxWidth` - Sets the width of each box. If not supplied, the width will use the
+	///       previously set box width, or be set to the spacing of the boxes
 	pub fn box_and_whisker<
 		'l,
 		Tx: DataType,
@@ -926,11 +926,11 @@ impl Axes2D
 	///
 	/// #Arguments:
 	/// * `mat` - Row-major 2D array signifying the value of the datapoints. The X and Y coordinates of the datapoints are determined automatically,
-	///           and optionally scaled using the `dimensions` argument.
+	///   and optionally scaled using the `dimensions` argument.
 	/// * `num_rows` - Number of rows in the data array
 	/// * `num_cols` - Number of columns in the data array
 	/// * `dimensions` - Optional X and Y coordinates of the first and last data points (with the rest of the coordinates spaced evenly between).
-	///                  By default this will be `(0, 0)` and `(num_rows - 1, num_cols - 1)`.
+	///   By default this will be `(0, 0)` and `(num_rows - 1, num_cols - 1)`.
 	/// * `options` - Array of PlotOption<&str> controlling the appearance of the surface. Relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	pub fn image<'l, T: DataType, X: IntoIterator<Item = T>>(

--- a/gnuplot/src/axes2d.rs
+++ b/gnuplot/src/axes2d.rs
@@ -895,6 +895,7 @@ impl Axes2D
 	///     * `BorderColor` - Sets the color of the border
 	///     * `Color` - Sets the color of the box fill
 	///     * `FillAlpha` - Sets the transparency of the box fill
+	#[allow(clippy::too_many_arguments)]
 	pub fn box_xy_error_low_high<
 		'l,
 		Tx: DataType,

--- a/gnuplot/src/axes3d.rs
+++ b/gnuplot/src/axes3d.rs
@@ -73,11 +73,11 @@ impl Axes3D
 	///
 	/// #Arguments:
 	/// * `mat` - Row-major 2D array signifying the Z coordinate of the datapoints. The X and Y coordinates of the datapoints are determined automatically,
-	///           and optionally scaled using the `dimensions` argument.
+	///   and optionally scaled using the `dimensions` argument.
 	/// * `num_rows` - Number of rows in the data array
 	/// * `num_cols` - Number of columns in the data array
 	/// * `dimensions` - Optional X and Y coordinates of the first and last data points (with the rest of the coordinates spaced evenly between).
-	///                  By default this will be `(0, 0)` and `(num_rows - 1, num_cols - 1)`.
+	///   By default this will be `(0, 0)` and `(num_rows - 1, num_cols - 1)`.
 	/// * `options` - Array of PlotOption controlling the appearance of the surface. Relevant options are:
 	///     * `Caption` - Specifies the caption for this dataset. Use an empty string to hide it (default).
 	pub fn surface<'l, T: DataType, X: IntoIterator<Item = T>>(
@@ -345,9 +345,9 @@ impl Axes3D
 	/// * `surface` - Show the contours on the surface itself
 	/// * `style` - Style of the contours
 	/// * `label` - Auto sets the label automatically and enables the legend, Fix() allows you specify a format string (using C style formatting),
-	///             otherwise an empty string disables the legend and labels.
+	///   otherwise an empty string disables the legend and labels.
 	/// * `levels` - Auto picks some default number of levels, otherwise you can pass a set nominal number instead. The number is nominal as
-	///              contours are placed at nice values of Z, and thus there may be fewer of them than this number.
+	///   contours are placed at nice values of Z, and thus there may be fewer of them than this number.
 	pub fn show_contours(
 		&mut self, base: bool, surface: bool, style: ContourStyle, label: AutoOption<&str>,
 		levels: AutoOption<u32>,
@@ -369,7 +369,7 @@ impl Axes3D
 	/// * `surface` - Show the contours on the surface itself
 	/// * `style` - Style of the contours
 	/// * `label` - Auto sets the label automatically and enables the legend, Fix() allows you specify a format string (using C style formatting),
-	///             otherwise an empty string disables the legend and labels.
+	///   otherwise an empty string disables the legend and labels.
 	/// * `levels` - A set of levels.
 	pub fn show_contours_custom<T: DataType, TC: IntoIterator<Item = T>>(
 		&mut self, base: bool, surface: bool, style: ContourStyle, label: AutoOption<&str>,

--- a/gnuplot/src/axes_common.rs
+++ b/gnuplot/src/axes_common.rs
@@ -612,12 +612,10 @@ impl PlotType
 		matches!(
 			*self,
 			Lines
-				| LinesPoints
-				| XErrorLines
+				| LinesPoints | XErrorLines
 				| Boxes | YErrorLines
-				| BoxAndWhisker
-				| BoxXYError | BoxErrorBars
-				| Polygons
+				| BoxAndWhisker | BoxXYError
+				| BoxErrorBars | Polygons
 		)
 	}
 
@@ -626,11 +624,9 @@ impl PlotType
 		matches!(
 			*self,
 			Points
-				| LinesPoints
-				| XErrorLines
-				| YErrorLines
-				| XErrorBars | YErrorBars
-				| XYErrorBars
+				| LinesPoints | XErrorLines
+				| YErrorLines | XErrorBars
+				| YErrorBars | XYErrorBars
 		)
 	}
 

--- a/gnuplot/src/axes_common.rs
+++ b/gnuplot/src/axes_common.rs
@@ -1372,7 +1372,7 @@ pub trait AxesCommon: AxesCommonPrivate
 	/// * `nrow` - Number of rows in the grid. Must be greater than 0.
 	/// * `ncol` - Number of columns in the grid. Must be greater than 0.
 	/// * `pos` - Which grid cell to place this axes in, counting from top-left corner,
-	///           going left and then down, starting at 0.
+	///   going left and then down, starting at 0.
 	fn set_pos_grid(&mut self, nrow: u32, ncol: u32, pos: u32) -> &mut Self
 	{
 		assert!(nrow > 0);
@@ -1417,7 +1417,7 @@ pub trait AxesCommon: AxesCommonPrivate
 	/// # Arguments
 	/// * `width` - Width of boxes.
 	/// * `is_relative` - if `true`, `width` is interpreted as a fraction of the default box width.
-	/// 	if `false` width is an absolute value in the units of the x axis
+	///   if `false` width is an absolute value in the units of the x axis
 	fn set_box_width(&mut self, width: f64, is_relative: bool) -> &mut Self
 	{
 		self.get_common_data_mut().box_width = Some((width, is_relative));
@@ -1539,9 +1539,9 @@ pub trait AxesCommon: AxesCommonPrivate
 	///
 	/// # Arguments
 	/// * `tick_placement` - Controls the placement of the ticks. Pass `None` to hide the ticks. Otherwise, the first tuple value controls the spacing
-	///                      of the major ticks (in axes units), otherwise set it to `Auto` to let gnuplot decide the spacing automatically. The second
-	///                      tuple value specifies the number of minor ticks. For logarithmic axes, non-zero values mean that the number of ticks usually
-	///                      equals to `ceil(log_base) - 2`.
+	///   of the major ticks (in axes units), otherwise set it to `Auto` to let gnuplot decide the spacing automatically. The second
+	///   tuple value specifies the number of minor ticks. For logarithmic axes, non-zero values mean that the number of ticks usually
+	///   equals to `ceil(log_base) - 2`.
 	/// * `tick_options` - Array of TickOption controlling the appearance of the ticks
 	/// * `label_options` - Array of LabelOption<&str> controlling the appearance of the tick labels. Relevant options are:
 	///      * `Offset` - Specifies the offset of the label
@@ -1627,8 +1627,8 @@ pub trait AxesCommon: AxesCommonPrivate
 	/// # Arguments
 	///
 	/// * `ticks` - The locations and labels of the added ticks.
-	///     The label can contain a single C printf style floating point formatting specifier which will be replaced by the
-	///     location of the tic.
+	///   The label can contain a single C printf style floating point formatting specifier which will be replaced by the
+	///   location of the tic.
 	/// * `tick_options` - Array of TickOption controlling the appearance of the ticks
 	/// * `label_options` - Array of LabelOption<&str> controlling the appearance of the tick labels. Relevant options are:
 	///      * `Offset` - Specifies the offset of the label
@@ -2065,7 +2065,7 @@ pub trait AxesCommon: AxesCommonPrivate
 	/// # Arguments
 	///
 	/// * `margins` - The values of margins to be overriden. Specified as a fraction of the
-	///               full drawing area, ranging from 0 to 1
+	///   full drawing area, ranging from 0 to 1
 	fn set_margins(&mut self, margins: &[MarginSide]) -> &mut Self
 	{
 		{

--- a/gnuplot/src/axes_common.rs
+++ b/gnuplot/src/axes_common.rs
@@ -612,10 +612,12 @@ impl PlotType
 		matches!(
 			*self,
 			Lines
-				| LinesPoints | XErrorLines
+				| LinesPoints
+				| XErrorLines
 				| Boxes | YErrorLines
-				| BoxAndWhisker | BoxXYError
-				| BoxErrorBars | Polygons
+				| BoxAndWhisker
+				| BoxXYError | BoxErrorBars
+				| Polygons
 		)
 	}
 
@@ -624,9 +626,11 @@ impl PlotType
 		matches!(
 			*self,
 			Points
-				| LinesPoints | XErrorLines
-				| YErrorLines | XErrorBars
-				| YErrorBars | XYErrorBars
+				| LinesPoints
+				| XErrorLines
+				| YErrorLines
+				| XErrorBars | YErrorBars
+				| XYErrorBars
 		)
 	}
 

--- a/gnuplot/src/axes_common.rs
+++ b/gnuplot/src/axes_common.rs
@@ -1088,6 +1088,7 @@ pub struct Size
 	h: f64,
 }
 
+#[allow(clippy::type_complexity)]
 pub struct AxesCommonData
 {
 	pub grid_options: Vec<PlotOption<String>>,

--- a/gnuplot/src/color.rs
+++ b/gnuplot/src/color.rs
@@ -297,7 +297,7 @@ impl<'l> From<&'l str> for ColorType<String>
 	}
 }
 
-impl<'l> From<String> for ColorType<String>
+impl From<String> for ColorType<String>
 {
 	/// Converts `String` into [RGBString]
 	fn from(value: String) -> Self

--- a/gnuplot/src/color.rs
+++ b/gnuplot/src/color.rs
@@ -33,7 +33,7 @@ pub enum ColorType<T = String>
 {
 	/// string (`&str` or `String`, but usually created with `&str`) in one of the following gnuplot-supported formats
 	/// - colorname   --- e.g. "blue" [See the gnuplot
-	///     [list of colornames](http://gnuplot.info/docs_6.0/loc11229.html)]
+	///   [list of colornames](http://gnuplot.info/docs_6.0/loc11229.html)]
 	/// - 0xRRGGBB    --- string containing hexadecimal constant
 	/// - 0xAARRGGBB  --- string containing hexadecimal constant
 	/// - #RRGGBB     --- string containing hexadecimal in x11 format

--- a/gnuplot/src/datatype.rs
+++ b/gnuplot/src/datatype.rs
@@ -72,7 +72,7 @@ impl DataType for Duration
 	}
 }
 
-impl<'l> DataType for &'l Duration
+impl DataType for &Duration
 {
 	fn get(&self) -> f64
 	{

--- a/gnuplot/src/figure.rs
+++ b/gnuplot/src/figure.rs
@@ -16,7 +16,6 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::str;
-use tempfile;
 
 enum AxesVariant
 {
@@ -175,7 +174,7 @@ impl Figure
 				.as_ref()
 				.and_then(|d| d.path().to_str())
 				.map(|s| s.into()),
-			data_tempdir: data_tempdir,
+			data_tempdir,
 		}
 	}
 
@@ -194,7 +193,7 @@ impl Figure
 		if self
 			.data_directory
 			.as_ref()
-			.map(|s| s == "")
+			.map(|s| s.is_empty())
 			.unwrap_or(false)
 		{
 			self.data_directory = self
@@ -402,7 +401,7 @@ impl Figure
 
 			if let Ok(version_string) = str::from_utf8(&output.stdout)
 			{
-				let parts: Vec<_> = version_string.split(|c| c == ' ' || c == '.').collect();
+				let parts: Vec<_> = version_string.split([' ', '.']).collect();
 				if parts.len() > 2 && parts[0] == "gnuplot"
 				{
 					if let (Ok(major), Ok(minor)) =

--- a/gnuplot/src/figure.rs
+++ b/gnuplot/src/figure.rs
@@ -748,7 +748,7 @@ fn flush_test()
 	use std::fs;
 	use tempfile::TempDir;
 
-	let tmp_path = TempDir::new().unwrap().into_path();
+	let tmp_path = TempDir::new().unwrap().keep();
 	let filename = tmp_path.join("plot.png");
 	let mut fg = Figure::new();
 	fg.axes2d().boxes(0..5, 0..5, &[]);

--- a/gnuplot/src/figure.rs
+++ b/gnuplot/src/figure.rs
@@ -160,6 +160,7 @@ impl Figure
 	pub fn new() -> Figure
 	{
 		let data_tempdir = tempfile::tempdir().ok();
+		#[allow(clippy::redundant_field_names)]
 		Figure {
 			axes: Vec::new(),
 			terminal: "".into(),
@@ -174,7 +175,7 @@ impl Figure
 				.as_ref()
 				.and_then(|d| d.path().to_str())
 				.map(|s| s.into()),
-			data_tempdir,
+			data_tempdir: data_tempdir,
 		}
 	}
 

--- a/gnuplot/src/options.rs
+++ b/gnuplot/src/options.rs
@@ -322,7 +322,7 @@ pub enum Tick<T, S>
 	Minor(T),
 }
 
-impl<'l, T: Clone, S: ToString> OneWayOwned for Tick<T, S>
+impl<T: Clone, S: ToString> OneWayOwned for Tick<T, S>
 {
 	type Output = Tick<T, String>;
 	fn to_one_way_owned(&self) -> Self::Output

--- a/gnuplot/src/options.rs
+++ b/gnuplot/src/options.rs
@@ -78,7 +78,7 @@ pub enum PlotOption<T>
 	BoxWidth(Vec<f64>),
 }
 
-impl<'l> OneWayOwned for PlotOption<&'l str>
+impl OneWayOwned for PlotOption<&str>
 {
 	type Output = PlotOption<String>;
 	fn to_one_way_owned(&self) -> Self::Output
@@ -258,7 +258,7 @@ pub enum LabelOption<T>
 	MarkerSize(f64),
 }
 
-impl<'l> OneWayOwned for LabelOption<&'l str>
+impl OneWayOwned for LabelOption<&str>
 {
 	type Output = LabelOption<String>;
 	fn to_one_way_owned(&self) -> Self::Output
@@ -295,7 +295,7 @@ pub enum TickOption<T>
 	Format(T),
 }
 
-impl<'l> OneWayOwned for TickOption<&'l str>
+impl OneWayOwned for TickOption<&str>
 {
 	type Output = TickOption<String>;
 	fn to_one_way_owned(&self) -> Self::Output
@@ -376,7 +376,7 @@ pub enum LegendOption<T>
 	MaxCols(u32),
 }
 
-impl<'l> OneWayOwned for LegendOption<&'l str>
+impl OneWayOwned for LegendOption<&str>
 {
 	type Output = LegendOption<String>;
 	fn to_one_way_owned(&self) -> Self::Output
@@ -433,7 +433,7 @@ pub enum PaletteType<T>
 	Custom(T),
 }
 
-impl<'l> OneWayOwned for PaletteType<&'l [(f32, f32, f32, f32)]>
+impl OneWayOwned for PaletteType<&[(f32, f32, f32, f32)]>
 {
 	type Output = PaletteType<Vec<(f32, f32, f32, f32)>>;
 	fn to_one_way_owned(&self) -> Self::Output
@@ -472,9 +472,9 @@ impl PaletteType<Vec<(f32, f32, f32, f32)>>
 			}
 			Formula(r, g, b) =>
 			{
-				assert!(r >= -36 && r <= 36, "Invalid r formula!");
-				assert!(g >= -36 && g <= 36, "Invalid g formula!");
-				assert!(b >= -36 && b <= 36, "Invalid b formula!");
+				assert!((-36..=36).contains(&r), "Invalid r formula!");
+				assert!((-36..=36).contains(&g), "Invalid g formula!");
+				assert!((-36..=36).contains(&b), "Invalid b formula!");
 				writeln!(w, "set palette rgbformulae {},{},{}", r, g, b);
 			}
 			CubeHelix(start, rev, sat, gamma) =>

--- a/gnuplot/src/util.rs
+++ b/gnuplot/src/util.rs
@@ -161,7 +161,7 @@ pub(crate) trait OneWayOwned
 	fn to_one_way_owned(&self) -> Self::Output;
 }
 
-impl<'l, T: OneWayOwned> OneWayOwned for &'l [T]
+impl<T: OneWayOwned> OneWayOwned for &[T]
 {
 	type Output = Vec<<T as OneWayOwned>::Output>;
 	fn to_one_way_owned(&self) -> Self::Output


### PR DESCRIPTION
Fixes to most warnings reported by `cargo clippy`
- Fixes to documentation indentation
- Removal of unnecessary lifetime annotations
- range contains lint
- comparison to empty lint
Also fixes warnings from cargo test
-  unnecessary parentheses around closure body
-  use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()

Remaining two issues are about function having too many parameters and are not as easily fixed.